### PR TITLE
Fix pytorch warnings

### DIFF
--- a/tests/loss_test.py
+++ b/tests/loss_test.py
@@ -6,5 +6,6 @@ import pytest
 
 def test_categorical_crossentropy():
     x = J.Variable(J.Tensor([[0.5, 0, 0.5, 0]]))
-    y = J.Variable(J.LongTensor([0, ]))
-    np.testing.assert_almost_equal(0.6931471824645996, categorical_crossentropy(x, y).data[0])
+    y = J.Variable(J.LongTensor([0]))
+    np.testing.assert_almost_equal(0.6931471824645996,
+                                   categorical_crossentropy(x, y).item())


### PR DESCRIPTION
This PR just fixes the pytorch warnings about outdated API. It involves 2 main fixes

- Use of `volatile` has been removed and now uses `torch.no_grad()`
- One test still used `.data[0]` for a scalar tensor. This has been replaced `.item()` as per pytorch guidelines.