### PR TITLE
Added new loss function setup

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -70,6 +70,7 @@ class MNISTModel(SLModel):
 
 
 model = MNISTModel()
+model.add_loss(nn.CrossEntropyLoss())
 
 # This will save the best scoring model weights to the current directory
 best_model = ModelCheckpoint(
@@ -99,7 +100,6 @@ model.fit_generator(
     epochs=10,
     steps_per_epoch=train_datagen.steps_per_epoch,
     optimizer=optimizer,
-    loss_fn=nn.CrossEntropyLoss(),
     validation_generator=val_datagen,
     validation_steps=val_datagen.steps_per_epoch,
     metrics=['accuracy', 'top3_accuracy'],

--- a/pyjet/data.py
+++ b/pyjet/data.py
@@ -238,6 +238,15 @@ class NpDataset(Dataset):
         self.x = x
         self.y = y
         self.ids = ids
+
+        assert isinstance(self.x, np.ndarray), "x must be a numpy array."
+        if self.y is not None:
+            assert isinstance(self.y, np.ndarray), "y must be a numpy array " \
+                "or None."
+        if self.ids is not None:
+            assert isinstance(self.ids, np.ndarray), "ids must be a numpy " \
+                "or None."
+
         self.output_labels = self.has_labels
         if self.has_labels:
             assert len(self.x) == len(
@@ -451,7 +460,6 @@ class ImageDataset(NpDataset):
         img = imread(path_to_img)
         # Then its a grayscale image
         if img.ndim == 2:
-            logging.info("Gray image?:", path_to_img)
             img = gray2rgb(img)
         # Cut out the alpha channel
         img = img[:, :, :3]

--- a/pyjet/layers/layer_utils.py
+++ b/pyjet/layers/layer_utils.py
@@ -4,14 +4,14 @@ import torch.nn.functional as F
 pool_types = {"no_pool": lambda *args, **kwargs: lambda x: x,
               "max": nn.MaxPool1d,
               "avg": nn.AvgPool1d}
-activation_types = {"linear": None,
-                    "relu": nn.ReLU,
-                    "softmax": nn.Softmax,
-                    "tanh": nn.Tanh}
+activation_types = {name.lower(): cls for name, cls in nn.modules.activation.__dict__.items() if isinstance(cls, type)}
+activation_types["linear"] = None
 
 
 def get_type(item_type, type_dict, fail_message):
     try:
+        if not isinstance(item_type, str):
+            return item_type
         return type_dict[item_type]
     except KeyError:
         raise NotImplementedError(fail_message)

--- a/pyjet/models.py
+++ b/pyjet/models.py
@@ -68,12 +68,13 @@ class SLModel(nn.Module):
     def loss(self, targets):
         return self.loss_manager.loss(self, targets)
 
-    def add_loss(self, loss_fn, *inputs, weight=1.0, name=None):
+    def add_loss(self, loss_fn, inputs=(), weight=1.0, name=None):
+        inputs = standardize_list_input(inputs)
         # Use 'loss_in' if no inputs provided
         if not len(inputs):
             inputs = ['loss_in']
         return self.loss_manager.add_loss(loss_fn,
-                                          *inputs,
+                                          inputs,
                                           weight=weight,
                                           name=name)
 

--- a/pyjet/test_utils.py
+++ b/pyjet/test_utils.py
@@ -5,10 +5,19 @@ import torch.nn.functional as F
 
 class ReluNet(SLModel):
     def forward(self, x):
-        return F.relu(x)
+        self.loss_in = F.relu(x)
+        return self.loss_in
 
 
 class ZeroAugmenter(Augmenter):
 
     def augment(self, x):
         return 0. * x
+
+
+def binary_loss(y_pred, y_true):
+    return (y_pred * y_true).sum()
+
+
+def multi_binary_loss(y_pred1, y_pred2, y_true):
+    return binary_loss(y_pred1, y_true) + binary_loss(y_pred2, y_true)

--- a/pyjet/training.py
+++ b/pyjet/training.py
@@ -164,7 +164,7 @@ class LossManager(object):
             self.__verify_loss_args = False
 
         # Compute the loss
-        return sum(self._compute_single_loss(targets, model, loss_name) for
+        return sum(self._compute_single_loss(model, targets, loss_name) for
                    loss_name in self.__loss_names)
 
     def get_loss_score(self, name=None):
@@ -185,6 +185,8 @@ class LossManager(object):
     def remove_loss(self, name=None):
         if name is None:
             name = self.__loss_names.pop()
+        else:
+            self.__loss_names.remove(name)
         loss_fn = self.__loss_dict.pop(name)
         inputs = self.__loss_input_dict.pop(name)
         weight = self.__loss_weight_dict.pop(name)

--- a/pyjet/training.py
+++ b/pyjet/training.py
@@ -174,8 +174,7 @@ class LossManager(object):
             name = self.__loss_names[0]
         return self.__loss_scores[name]
 
-    # TODO: Thoughts on changing inputs to a list instead?
-    def add_loss(self, loss_fn, *inputs, weight=1.0, name=None):
+    def add_loss(self, loss_fn, inputs, weight=1.0, name=None):
         if name is None:
             name = "loss_{}".format(len(self.__loss_dict))
         self.__loss_dict[name] = loss_fn

--- a/pyjet/utils.py
+++ b/pyjet/utils.py
@@ -1,1 +1,19 @@
+import copy
 
+
+def resettable(f):
+    """
+    Decorator to make a python object resettable. Note that this will
+    no work with inheritance. To reset an object, simply call its reset
+    method.
+    """
+    def __init_and_copy__(self, *args, **kwargs):
+        f(self, *args)
+        self.__original_dict__ = copy.deepcopy(self.__dict__)
+
+        def reset(o=self):
+            o.__dict__ = o.__original_dict__
+
+        self.reset = reset
+
+    return __init_and_copy__

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,7 +1,7 @@
 import pyjet
 from pyjet.metrics import Accuracy
 from pyjet.losses import categorical_crossentropy
-from pyjet.test_utils import ReluNet
+from pyjet.test_utils import ReluNet, binary_loss, multi_binary_loss
 import math
 import numpy as np
 import pytest
@@ -11,6 +11,16 @@ import pytest
 def relu_net():
     net = ReluNet()
     return net
+
+
+@pytest.fixture
+def binary_loss_fn():
+    return binary_loss
+
+
+@pytest.fixture
+def multi_binary_loss_fn():
+    return multi_binary_loss
 
 
 def test_predict_batch(relu_net):
@@ -27,3 +37,54 @@ def test_validate_batch(relu_net):
     expected_loss = -(math.log(x[0, y[0]]) + math.log(x[1, y[1]])) / 2
     assert math.isclose(loss, expected_loss, rel_tol=1e-7)
     assert accuracy_score == 50.
+
+
+def test_loss(relu_net, binary_loss_fn, multi_binary_loss_fn):
+    x = np.array([[-1., 1., 0., 1.],
+                  [-2., 0., 1., 1.]])
+    y = np.array([[1., 1., 0., 1.],
+                  [1., 0., 1., 1.]])
+    x_torch = relu_net.cast_input_to_torch(x)
+    y_torch = relu_net.cast_target_to_torch(y)
+
+    # Test it without passing it inputs
+    assert len(relu_net.loss_manager) == 0
+    relu_net.add_loss(binary_loss_fn)
+    pred = relu_net(x_torch)
+    assert relu_net.loss(y_torch) == 4.
+
+    # Test it it with an input of 'loss_in'
+    relu_net.clear_losses()
+    assert len(relu_net.loss_manager) == 0
+    relu_net.add_loss(binary_loss_fn, inputs='loss_in')
+    pred = relu_net(x_torch)
+    assert relu_net.loss(y_torch) == 4.
+
+    # Test it it with an input that's not 'loss_in' and using multi loss
+    relu_net.add_loss(binary_loss_fn, inputs=['loss_in2'], name="new_loss")
+    pred = relu_net(x_torch)
+    relu_net.loss_in2 = pred
+    assert relu_net.loss(y_torch) == 8.
+    # Check that the individual loss values were also calculated
+    assert relu_net.loss_manager.get_loss_score('loss_0') == 4.
+    assert relu_net.loss_manager.get_loss_score('new_loss') == 4.
+
+    # Now try removing the loss
+    loss_info = relu_net.remove_loss(name="new_loss")
+    assert loss_info["name"] == "new_loss"
+    assert loss_info["loss"] == binary_loss_fn
+    assert loss_info["inputs"] == ["loss_in2"]
+    assert loss_info["weight"] == 1.0
+
+    # Pop the last loss
+    loss_info = relu_net.remove_loss()
+    assert loss_info["name"] == "loss_0"
+    assert loss_info["loss"] == binary_loss_fn
+    assert loss_info["inputs"] == ["loss_in"]
+    assert loss_info["weight"] == 1.0
+
+    # Now try adding a multi input loss
+    relu_net.add_loss(multi_binary_loss_fn, inputs=['loss_in', 'loss_in2'])
+    pred = relu_net(x_torch)
+    relu_net.loss_in2 = pred
+    assert relu_net.loss(y_torch) == 8.


### PR DESCRIPTION
# Better Loss Function Setup and Support for Arbitrarily Complex Model Losses

This PR extends loss functions for model to be arbitrarily complex, a major step forward for PyJet, providing functionality not supported by Keras. Below I've outlined the changes and additions, along with examples of the new possible workflows.

## Examples

### Adding loss functions for training

Below are some examples of workflows, starting with the most simple (the old, but still supported API) to very complex arbitrary loss functions. Keep in mind that when we use the `add_loss` method, the loss function passed as the input must take its input as
```python
some_loss_function(input1, input2, ..., inputN, targets)
```
Most loss functions will be of the form
```python
some_loss_function(input1, targets)
```

- With this first example, we create our own PyTorch module as our model, and pass it to `SLModel`. `SLModel` will use the output of the module as the input for the loss function:
```python
pytorch_model = FullyConnected(128, 64)
# Now pass the pytorch model into SLModel, and fit it
model = SLModel(torch_module=pytorch_model)
model.fit_generator(...,
                    loss_fn=categorical_cross_entropy,
                    ...)
``` 
The output of `pytorch_model` is used as the input into the `categorical_cross_entropy` loss function.

- In the second example, we override the forward method of `SLModel`, but still only use one loss function. However, we can use an intermediate value in the model as the input to the loss function. This will be the most common use case. Most often you'll want to use the **logits** as the input into your loss function instead of the actual model output, since this makes the training much more stable.
```python
import torch.nn.functional as F

class SimpleNet(SLModel):
    def __init__(self):
        self.fc1 = FullyConnected(128, 64, activation='relu')
        self.fc2 = FullyConnected(64, 1)

    def forward(self, x):
        x = self.fc1(x)
        self.loss_in = self.fc2(x)
        return F.sigmoid(self.loss_in)

model = SimpleNet()
```
Now we have 3 different similar ways to use the loss function that takes as input `self.loss_in`. `self.loss_in` is the default name for the loss input, so if we don't specify any inputs, the model will infer that `self.loss_in` is the input for the loss. If for some reason, you misspell it, upon running the first input, the model will raise an `AttributeError`.

Option 1 (using `fit_generator`):
```python
# Using fit_gnerator's loss_fn will default to using self.loss_in as
# the loss function input
model.fit_generator(...,
                    loss_fn=binary_cross_entropy_with_logits,
                    ...)
```

Option 2 (using the model's internal `loss_manager`)
```python
# Not specifying any inputs will default to using self.loss_in as
# the loss function input
model.add_loss(binary_cross_entropy_with_logits)
# This is the default behavior of fit_generator, no need to explicitly pass
# loss_fn as None
model.fit_generator(...,
                    loss_fn=None,
                    ...)
```

Option 3 (using the model's internal `loss_manager`, but specifying an input)
```python
# Here we explicitly specify we want to use self.loss_in as the input
# to our loss function.
model.add_loss(binary_cross_entropy_with_logits, inputs='loss_in')
# This is the default behavior of fit_generator, no need to explicitly pass
# loss_fn as None
model.fit_generator(...,
                    loss_fn=None,
                    ...)
```

- In the third example, we'll use a loss function with multiple inputs. Since this is more complicated, we'll be restricted to using the model's `loss_manager` instead of just simply using `fit_generator`. 

```python
import torch.nn.functional as F

class SimpleNet(SLModel):
    def __init__(self):
        self.fc1 = FullyConnected(128, 64, activation='relu')
        self.fc2 = FullyConnected(64, 1)
        self.fc2_2 = FullyConnected(64, 1)

    def forward(self, x):
        x = self.fc1(x)
        self.loss_in_1 = self.fc2(x)
        self.loss_in_2 = self.fc2_2(x)
        return F.sigmoid(self.loss_in_1 + self.loss_in_2)

model = SimpleNet()
```

Now that we've specified our model, we can add our `multi_input_loss`:

```python
model.add_loss(multi_input_loss, inputs=['loss_in_1', 'loss_in_2'])
```
And it's as simple as that!

- In the fourth example below we'll use multiple loss functions. When performing the optimization, the model's `loss_manager` will sum up the two losses with equal weights. It will also log each individual loss as well as the combined loss function if verbosity is set during training. The example below will go over a simplified use case where you might want to regularize your model using some kind reconstruction loss:

```python
import torch.nn.functional as F

class SimpleNet(SLModel):
    def __init__(self):
        self.fc1 = FullyConnected(128, 64, activation='relu')
        self.fc2 = FullyConnected(64, 1)
        self.reconstuct_fc = FullyConnected(64, 128)

    def forward(self, x):
        x = self.fc1(x)
        self.main_loss_in = self.fc2(x)
        self.reconstruct_loss_in = self.reconstruct_fc(x)
        return F.sigmoid(self.main_loss_in)

model = SimpleNet()
```

Now that we've specified our model, we can add both our losses:

```python
model.add_loss(binary_cross_entropy_with_logits, inputs='main_loss_in', name='main_loss')
model.add_loss(mean_squared_error, inputs='reconstruct_loss_in', name='reconstruct_loss')
model.fit_generator(...)
```

Say we wanted to give the two losses different weights. That's extremely simple as illustrated below:

```python
# The weight is by default 1, so we don't have to explicitly specify it
model.add_loss(binary_cross_entropy_with_logits, inputs='main_loss_in', name='main_loss', weight=1.)
model.add_loss(mean_squared_error, inputs='reconstruct_loss_in', name='reconstruct_loss', weight=0.001)
model.fit_generator(...)
```

The total loss will be the weighted sum of all the input losses.

### Overriding the `loss` method

If you want totally new loss behavior it is possible to override the loss function. However, this is highly discouraged. Not only will it completely invalidate the internal model's loss manager, it could also have undefined behavior if any code depends on the internal loss manager

### Removing loss functions

Removing loss functions is very easy. To remove our most recently added loss to `model` we simply call:

```python
model.remove_loss()
```

If we want to remove a specific named loss, we can call

```python
model.remove_loss(name="mse_loss")
```
To clear all the losses from a model, we can call:

```python
model.clear_losses()
```

## Summary of Changes Made

Created a `LossManager` class to handle a model's internal management of losses. It allows for adding, removing, and clearing losses. In addition, users can name added losses and give each loss a weight. The `SLModel` picks up these basic methods (adding, removing, and clearing) for interfacing with its internal loss manager.

In addition, the `compile_loss` method has been modified to create metrics out of both the composite loss and any auxilary losses that make up the composite loss. These metrics are added to the metrics list for training.

Other misc additions
* Added a resettable decorator to the utils. Decorating the `__init__` method of a class gives the class a reset method to return it to its original state.
* Lowercase string names for all pytorch activations are now mapped to their respective activations.

## Tests

Added tests for all use cases described above except for overriding the loss method.
